### PR TITLE
Update actions/checkout to v3 to fix Node12 vs. Node16 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: upload
         uses: biglocalnews/upload-files@main
@@ -26,7 +26,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: upload
         uses: biglocalnews/upload-files@main


### PR DESCRIPTION
Getting dozens of warnings from the WARN actions workflows because they're trying to use an old version of Node.
